### PR TITLE
fix: get errors from session._flashed instead of session._errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:

--- a/src/InertiaResponse.imba
+++ b/src/InertiaResponse.imba
@@ -74,18 +74,17 @@ export class InertiaResponse
 		return shared
 
 	def resolveValidationErrors request\Request
-		if !request.request.session._errors then return { errors: {} }
+		if !(request.request.session && request.request.session._flashed && request.request.session._flashed._errors)
+			return { errors: {} }
 
-		const errors = request.request.session._errors
+		const errors = request.request.session._flashed._errors
 
-		delete request.request.session._errors
-
-		return errors
+		return { errors }
 
 	def resolveRootViewProps request\Request
 		const rootViewProps = {
 			locale: request.locale!
-			flash: without(request.req.session._flashed ?? {}, ['_old'])
+			flash: without(request.req.session._flashed ?? {}, ['_old', '_errors'])
 		}
 
 		delete request.req.session._flashed


### PR DESCRIPTION
<!-- This is adapted from github.com/imba/imba -->

<!-- Provide a general summary of your changes in the Title above -->

## Description
Change how errors are retrieved 
<!-- Describe your changes in detail -->

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Ran manual tests
<!-- Please describe in detail how you tested your changes. -->

<!-- Include details of your testing environment, tests ran to see how -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
